### PR TITLE
Use macos-14(m1) runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,40 +15,40 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    # Setup
-    - name: Show versions
-      run: |
-        rustc --version
-        cargo --version
-    - uses: actions/checkout@v4
-    - uses: Swatinem/rust-cache@v2
+      # Setup
+      - name: Show versions
+        run: |
+          rustc --version
+          cargo --version
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
 
-    # Execute
-    - name: Format check
-      id: format
-      continue-on-error: true
-      run: cargo fmt --check --message-format=short
-    - name: Lint
-      id: lint
-      continue-on-error: true
-      run: cargo clippy
+      # Execute
+      - name: Format check
+        id: format
+        continue-on-error: true
+        run: cargo fmt --check --message-format=short
+      - name: Lint
+        id: lint
+        continue-on-error: true
+        run: cargo clippy
 
-    - name: Setup nextest
-      run: |
-        curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
-    - name: test
-      run: |
-        cargo nextest run
-    - uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: junit test reports
-        path: target/nextest/default
+      - name: Setup nextest
+        run: |
+          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+      - name: test
+        run: |
+          cargo nextest run
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: junit test reports
+          path: target/nextest/default
 
-    # Post process
-    - name: Set status failure when format or lint step failed
-      if: steps.format.outcome != 'success' || steps.lint.outcome != 'success'
-      run: exit 1
+      # Post process
+      - name: Set status failure when format or lint step failed
+        if: steps.format.outcome != 'success' || steps.lint.outcome != 'success'
+        run: exit 1
 
   build:
     strategy:
@@ -70,26 +70,26 @@ jobs:
     name: Build ${{ matrix.job.target }}
     runs-on: ${{ matrix.job.os }}
     steps:
-    - name: Show versions
-      run: |
-        rustc --version
-        cargo --version
-    - uses: actions/checkout@v4
-    - uses: Swatinem/rust-cache@v2
-    - name: Setup rust build target
-      run: rustup target add ${{ matrix.job.target }}
+      - name: Show versions
+        run: |
+          rustc --version
+          cargo --version
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - name: Setup rust build target
+        run: rustup target add ${{ matrix.job.target }}
 
-    - name: Build
-      run: |
-        if [[ "${{ matrix.job.target }}" == "wasm32-wasi" ]]; then
-          cargo install cargo-wasi
-          cargo wasi build --release --target ${{ matrix.job.target }}
-        else
-          cargo build --release --target ${{ matrix.job.target }}
-        fi
+      - name: Build
+        run: |
+          if [[ "${{ matrix.job.target }}" == "wasm32-wasi" ]]; then
+            cargo install cargo-wasi
+            cargo wasi build --release --target ${{ matrix.job.target }}
+          else
+            cargo build --release --target ${{ matrix.job.target }}
+          fi
 
-    - name: Upload Artifacts
-      uses: actions/upload-artifact@v4
-      with:
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
           name: ${{ matrix.job.target }}
           path: target/${{ matrix.job.target }}/release/${{ matrix.job.bin }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,10 +61,10 @@ jobs:
           - os: ubuntu-20.04
             target: wasm32-wasi
             bin: junit2json.wasm
-          - os: macos-latest
+          - os: macos-14
             target: x86_64-apple-darwin
             bin: junit2json
-          - os: macos-latest
+          - os: macos-14
             target: aarch64-apple-darwin
             bin: junit2json
     name: Build ${{ matrix.job.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,8 @@ jobs:
   publish_release:
     name: Release
     environment:
-        name: prod
-        url: https://crates.io/crates/junit2json
+      name: prod
+      url: https://crates.io/crates/junit2json
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch'
     needs: [draft_release]
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.ref }}
           token: ${{ steps.app-token.outputs.token }}
-          
+
       - name: Setup git author
         run: |
           git config user.name github-actions
@@ -87,24 +87,24 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     needs: ["draft_release", "publish_release"]
     steps:
-    - uses: actions/checkout@v4
-    - name: Setup rust build target
-      run: rustup target add ${{ matrix.job.target }}
+      - uses: actions/checkout@v4
+      - name: Setup rust build target
+        run: rustup target add ${{ matrix.job.target }}
 
-    - name: Build
-      run: |
-        if [[ "${{ matrix.job.target }}" == "wasm32-wasi" ]]; then
-          cargo install cargo-wasi
-          cargo wasi build --release --target ${{ matrix.job.target }}
-        else
-          cargo build --release --target ${{ matrix.job.target }}
-        fi
+      - name: Build
+        run: |
+          if [[ "${{ matrix.job.target }}" == "wasm32-wasi" ]]; then
+            cargo install cargo-wasi
+            cargo wasi build --release --target ${{ matrix.job.target }}
+          else
+            cargo build --release --target ${{ matrix.job.target }}
+          fi
 
-    - name: Upload assets
-      run: |
-        ASSET_NAME="junit2json-rs-${{ needs.draft_release.outputs.version_name }}-${{ matrix.job.target}}.tar.gz"
-        cp target/${{ matrix.job.target }}/release/${{ matrix.job.bin }} ./${{ matrix.job.bin }}
-        tar -zcvf "${ASSET_NAME}" ${{ matrix.job.bin }}
-        gh release upload ${{ needs.draft_release.outputs.tag_name }} "${ASSET_NAME}" --clobber
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload assets
+        run: |
+          ASSET_NAME="junit2json-rs-${{ needs.draft_release.outputs.version_name }}-${{ matrix.job.target}}.tar.gz"
+          cp target/${{ matrix.job.target }}/release/${{ matrix.job.bin }} ./${{ matrix.job.bin }}
+          tar -zcvf "${ASSET_NAME}" ${{ matrix.job.bin }}
+          gh release upload ${{ needs.draft_release.outputs.tag_name }} "${ASSET_NAME}" --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,10 +76,10 @@ jobs:
           - os: ubuntu-20.04
             target: wasm32-wasi
             bin: junit2json.wasm
-          - os: macos-latest
+          - os: macos-14
             target: x86_64-apple-darwin
             bin: junit2json
-          - os: macos-latest
+          - os: macos-14
             target: aarch64-apple-darwin
             bin: junit2json
     name: Upload assets ${{ matrix.job.target }}


### PR DESCRIPTION
ref:
https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-private-repositories