### PR TITLE
Add attestations to build binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,10 @@ jobs:
         run: exit 1
 
   build:
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -93,6 +97,10 @@ jobs:
         with:
           name: ${{ matrix.job.target }}
           path: target/${{ matrix.job.target }}/release/${{ matrix.job.bin }}
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: target/${{ matrix.job.target }}/release/${{ matrix.job.bin }}
 
 
   actions-timeline:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,12 @@ on:
     branches:
       - main
   workflow_dispatch:
-permissions:
-  contents: write
-  deployments: write
 jobs:
   draft_release:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      deployments: write
     outputs:
       tag_name: ${{ steps.release-drafter.outputs.tag_name }}
       version_name: ${{ env.VERSION }}
@@ -31,6 +31,9 @@ jobs:
       name: prod
       url: https://crates.io/crates/junit2json
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      deployments: write
     if: github.event_name == 'workflow_dispatch'
     needs: [draft_release]
     steps:
@@ -66,6 +69,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   upload_assets:
+    permissions:
+      id-token: write
+      attestations: write
+      contents: write
+      deployments: write
     strategy:
       fail-fast: false
       matrix:
@@ -108,3 +116,7 @@ jobs:
           gh release upload ${{ needs.draft_release.outputs.tag_name }} "${ASSET_NAME}" --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: target/${{ matrix.job.target }}/release/${{ matrix.job.bin }}


### PR DESCRIPTION
Add attestations to released binary.
Everyone can verify binary attestations using `gh attestation verify`.

ref: https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#generating-build-provenance-for-binaries