### PR TITLE
ci: fix deprecation warnings in release workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,43 +2,41 @@ name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 categories:
   - title: 'BREAKING CHANGES'
-    labels:
-      - 'BREAKING CHANGES'
+    semver-increment: major
+    when:
+      labels:
+        - 'BREAKING CHANGES'
   - title: 'Features'
-    labels:
-      - 'feature'
-      - 'enhancement'
+    semver-increment: minor
+    when:
+      labels:
+        - 'feature'
+        - 'enhancement'
   - title: 'Fixes'
-    labels:
-      - 'fix'
-      - 'bug'
-      - 'security'
+    semver-increment: patch
+    when:
+      labels:
+        - 'fix'
+        - 'bug'
+        - 'security'
   - title: 'Dependencies'
     collapse-after: 3
-    labels:
-      - 'dependencies'
-      - 'renovate'
+    when:
+      labels:
+        - 'dependencies'
+        - 'renovate'
   - title: 'Documentation'
-    labels:
-      - 'document'
-      - 'documentation'
+    when:
+      labels:
+        - 'document'
+        - 'documentation'
   - title: 'Internal improvement'
-    labels:
-      - 'ci'
+    when:
+      labels:
+        - 'ci'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:
-  major:
-    labels:
-      - 'BREAKING CHANGES'
-  minor:
-    labels:
-      - 'feature'
-      - 'enhancement'
-  patch:
-    labels:
-      - 'bug'
-      - 'security'
   default: patch
 template: |
   ## [v$RESOLVED_VERSION](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ secrets.BYPASS_APP_ID }}
+          client-id: ${{ secrets.BYPASS_APP_ID }}
           private-key: ${{ secrets.BYPASS_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
## Summary

Fix deprecation warnings in the release workflow.

## Changes

### Migrate `.github/release-drafter.yml` to release-drafter v7 schema

- Move each category's `labels` field into a `when` condition (`when.labels`)
- Embed `semver-increment` directly on the `BREAKING CHANGES`, `Features`, and `Fixes` categories
- Remove now-empty `version-resolver.major`, `minor`, and `patch` sections, keeping only `version-resolver.default: patch`

### Fix `app-id` deprecation in `actions/create-github-app-token`

- Changed the `app-id` input to `client-id` as required by the newer version of the action

## Reference

Same fixes were previously applied to [Kesin11/actions-timeline](https://github.com/Kesin11/actions-timeline) and [Kesin11/ts-junit2json](https://github.com/Kesin11/ts-junit2json):
- PR [#347](https://github.com/Kesin11/actions-timeline/pull/347) — release-drafter v7 migration
- PR [#359](https://github.com/Kesin11/actions-timeline/pull/359) — `app-id` → `client-id`
- PR [#434](https://github.com/Kesin11/ts-junit2json/pull/434) — both fixes